### PR TITLE
Remove macro_export unnecessary for test

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -150,7 +150,6 @@ fn test_pattern_macro() {
 fn test_attributes() {
     mashup! {
         /// Needs better documentation.
-        #[macro_export]
         #[doc(hidden)]
         m["T"] = A a;
     }


### PR DESCRIPTION
Work around the breaking change in https://github.com/rust-lang/rust/pull/52234#issuecomment-404563901.