### PR TITLE
support mashup use of env!("varname")

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -159,6 +159,45 @@ fn test_keyword() {
     let _ = Fmove;
 }
 
+#[test]
+fn test_literal_str() {
+    mashup! {
+        m["x"] = Foo "Bar";
+    }
+
+    m! {
+        struct "x";
+    }
+
+    let _ = FooBar;
+}
+
+#[test]
+fn test_env_literal() {
+    mashup! {
+        m["x"] = Lib env;
+    }
+
+    m! {
+        struct "x";
+    }
+
+    let _ = Libenv;
+}
+
+#[test]
+fn test_env_present() {
+    mashup! {
+        m["x"] = Lib env!("CARGO_PKG_NAME");
+    }
+
+    m! {
+        struct "x";
+    }
+
+    let _ = Libmashup;
+}
+
 macro_rules! conditionally_ignore {
     {
         #[cfg(not($cfg:ident))]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -175,14 +175,14 @@ fn test_literal_str() {
 #[test]
 fn test_env_literal() {
     mashup! {
-        m["x"] = Lib env;
+        m["x"] = Lib env bar;
     }
 
     m! {
         struct "x";
     }
 
-    let _ = Libenv;
+    let _ = Libenvbar;
 }
 
 #[test]


### PR DESCRIPTION
fixes https://github.com/dtolnay/mashup/issues/11

This actually fixes another bug I found unexpected with the stringification of `TokenStream::Literal(...)` types the issue above as well. Two birds with one stone. I added test cases to cover my changes. This macro panics if the env var is not present with a hopefully helpful message. I wasn't sure how to cover that in a test case. Rust has `#[should_panic]` attribute for tests but that's don't panic at runtime not at compile time :)