### PR TITLE
use proc_macro proper

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -12,7 +12,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro-hack = "0.4"
-proc-macro2 = "0.4"
 
 [badges]
 travis-ci = { repository = "dtolnay/mashup" }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -3,8 +3,8 @@
 #[macro_use]
 extern crate proc_macro_hack;
 
-extern crate proc_macro2;
-use proc_macro2::{Delimiter, Ident, Literal, TokenStream, TokenTree};
+extern crate proc_macro;
+use proc_macro::{Delimiter, Ident, Literal, TokenStream, TokenTree};
 
 use std::collections::BTreeMap as Map;
 use std::str::FromStr;


### PR DESCRIPTION
@dtolnay I'm not entirely sure this will help with #16 but it may hold enough value on its on. Now that the [proc_macro](https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html) works on stable I don't actually see the usecase for proc_macro2 which I think was just a shim to get it working on stable until it became stable. All the tests pass. Let me know if I'm missing anything noteworthy.