### PR TITLE
(WIP) Proc macro stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ language: rust
 
 matrix:
   include:
-    - rust: 1.15.0
-      env: RUSTFLAGS="--cfg no_attributes --cfg no_raw_identifiers"
-      script: cargo test --test test
-    - rust: 1.20.0
+    - rust: 1.30.0
       env: RUSTFLAGS="--cfg no_raw_identifiers"
       script: cargo test
     - rust: stable

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -12,7 +12,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro-hack = "0.4"
-proc-macro2 = "0.4"
 
 [badges]
 travis-ci = { repository = "dtolnay/mashup" }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -55,6 +55,7 @@ fn identify(lit: &Literal) -> String {
     }
 }
 
+// expects a single line of syntax tokens in the form {name}[{tag}] = {pieces...};
 fn parse(tts: TokenStream) -> Input {
     let mut tts = tts.into_iter().peekable();
     let mut map = Map::new();

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -3,8 +3,8 @@
 #[macro_use]
 extern crate proc_macro_hack;
 
-extern crate proc_macro2;
-use proc_macro2::{Delimiter, Ident, Literal, TokenStream, TokenTree};
+extern crate proc_macro;
+use proc_macro::{Delimiter, Ident, Literal, TokenStream, TokenTree};
 
 use std::collections::BTreeMap as Map;
 use std::str::FromStr;


### PR DESCRIPTION
The end result of this should hopefully be the follow up on https://github.com/dtolnay/mashup/pull/17#pullrequestreview-169541383 and close out https://github.com/dtolnay/mashup/issues/16

I expect I'll have a lot of questions so I'm going to let this pr be a point of reference with a checklist to keep track of where I am along the way

- [X] drop [proc-macro2](https://crates.io/crates/proc-macro2)
- [X] set min supported rust version in travis to 1.30.0
- [ ] drop [proc-macro-hack](https://crates.io/crates/proc-macro-hack)
- [ ] convert mashup to function like proc macro?
- [ ] profit (able to to use 2018 imports)